### PR TITLE
Remove default enum values

### DIFF
--- a/sdk/src/main/kotlin/org/ocast/sdk/core/ReferenceDevice.kt
+++ b/sdk/src/main/kotlin/org/ocast/sdk/core/ReferenceDevice.kt
@@ -374,7 +374,6 @@ open class ReferenceDevice(upnpDevice: UpnpDevice) : Device(upnpDevice), WebSock
                         applicationSemaphore?.release()
                     }
                     WebAppStatus.DISCONNECTED -> isApplicationRunning.set(false)
-                    else -> {}
                 }
             }
             Service.MEDIA -> {

--- a/sdk/src/main/kotlin/org/ocast/sdk/core/models/OCast.kt
+++ b/sdk/src/main/kotlin/org/ocast/sdk/core/models/OCast.kt
@@ -16,7 +16,6 @@
 
 package org.ocast.sdk.core.models
 
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
@@ -168,11 +167,7 @@ class OCastRawDeviceLayer(
         @JsonProperty("forbidden_unsecure_mode ") FORBIDDEN_UNSECURE_MODE,
 
         /** There is an internal error. */
-        @JsonProperty("internal_error") INTERNAL_ERROR,
-
-        /** The status is unknown. */
-        @JsonEnumDefaultValue
-        @JsonProperty("unknown") UNKNOWN
+        @JsonProperty("internal_error") INTERNAL_ERROR
     }
 
     /**

--- a/sdk/src/main/kotlin/org/ocast/sdk/core/models/WebApp.kt
+++ b/sdk/src/main/kotlin/org/ocast/sdk/core/models/WebApp.kt
@@ -17,7 +17,6 @@
 
 package org.ocast.sdk.core.models
 
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
@@ -39,9 +38,5 @@ enum class WebAppStatus {
     @JsonProperty("connected") CONNECTED,
 
     /** The web app is disconnected from the web socket server. */
-    @JsonProperty("disconnected") DISCONNECTED,
-
-    /** The web app status is unknown. */
-    @JsonEnumDefaultValue
-    @JsonProperty("unknown") UNKNOWN
+    @JsonProperty("disconnected") DISCONNECTED
 }


### PR DESCRIPTION
Default enum values are useless because decoding is always surrounded by a try / catch block